### PR TITLE
Add backend CRUD for Customers, MonthlyPasses, and Visits

### DIFF
--- a/cms-app/src/api/monthly-subscription-crud.js
+++ b/cms-app/src/api/monthly-subscription-crud.js
@@ -1,0 +1,301 @@
+import { doc, setDoc, getDoc, updateDoc, deleteDoc, collection, getDocs, serverTimestamp } from "firebase/firestore";
+import { db } from "./firebaseconfig";
+
+const CUSTOMERS_COLLECTION = "Customers";
+const MONTHLY_PASSES_COLLECTION = "MonthlyPasses";
+
+function cleanText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function cleanAddress(address = {}) {
+  return {
+    streetAddress: cleanText(address.streetAddress),
+    city: cleanText(address.city),
+    state: cleanText(address.state),
+    zipCode: cleanText(address.zipCode)
+  };
+}
+
+function cleanVehicleInfo(vehicleInfo = {}) {
+  return {
+    year: cleanText(vehicleInfo.year),
+    make: cleanText(vehicleInfo.make),
+    model: cleanText(vehicleInfo.model),
+    color: cleanText(vehicleInfo.color)
+  };
+}
+
+function createGeneratedDocRef(collectionName) {
+  return doc(collection(db, collectionName));
+}
+
+function cleanCustomerUpdates(updates = {}) {
+  return {
+    ...(updates.name !== undefined ? { name: cleanText(updates.name) } : {}),
+    ...(updates.contactPerson !== undefined ? { contactPerson: cleanText(updates.contactPerson) } : {}),
+    ...(updates.address !== undefined ? { address: cleanAddress(updates.address) } : {}),
+    ...(updates.phone !== undefined ? { phone: cleanText(updates.phone) } : {}),
+    ...(updates.email !== undefined ? { email: cleanText(updates.email) } : {})
+  };
+}
+
+function cleanMonthlyPassUpdates(updates = {}) {
+  return {
+    ...(updates.customerId !== undefined ? { customerId: cleanText(updates.customerId) } : {}),
+    ...(updates.planType !== undefined ? { planType: cleanText(updates.planType).toLowerCase() } : {}),
+    ...(updates.planNumberId !== undefined ? { planNumberId: cleanText(updates.planNumberId) } : {}),
+    ...(updates.vehicleInfo !== undefined ? { vehicleInfo: cleanVehicleInfo(updates.vehicleInfo) } : {}),
+    ...(updates.notes !== undefined ? { notes: cleanText(updates.notes) } : {}),
+    ...(updates.status !== undefined ? { status: cleanText(updates.status) } : {}),
+    ...(updates.updateInfoFlag !== undefined ? { updateInfoFlag: Boolean(updates.updateInfoFlag) } : {})
+  };
+}
+
+function buildCustomerRecord(customer = {}) {
+  return {
+    name: cleanText(customer.name),
+    contactPerson: cleanText(customer.contactPerson),
+    address: cleanAddress(customer.address),
+    phone: cleanText(customer.phone),
+    email: cleanText(customer.email),
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp()
+  };
+}
+
+function buildMonthlyPassRecord(monthlyPass = {}) {
+  return {
+    customerId: cleanText(monthlyPass.customerId),
+    planType: cleanText(monthlyPass.planType).toLowerCase(),
+    planNumberId: cleanText(monthlyPass.planNumberId),
+    vehicleInfo: cleanVehicleInfo(monthlyPass.vehicleInfo),
+    notes: cleanText(monthlyPass.notes),
+    status: 'needs credit card information',
+    updateInfoFlag: true,
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+    closedAt: null
+  };
+}
+
+async function createCustomer(customer = {}) {
+  const customerRecord = buildCustomerRecord(customer);
+
+  if (!customerRecord.name) {
+    throw new Error('Customer name is required.');
+  }
+
+  const customerRef = createGeneratedDocRef(CUSTOMERS_COLLECTION);
+  await setDoc(customerRef, customerRecord);
+
+  return customerRef.id;
+}
+
+async function getCustomer(customerId) {
+  try {
+    const docRef = doc(db, CUSTOMERS_COLLECTION, customerId);
+    const docSnap = await getDoc(docRef);
+
+    if (!docSnap.exists()) {
+      return null;
+    }
+
+    return {
+      id: docSnap.id,
+      ...docSnap.data()
+    };
+  } catch (error) {
+    console.error('Error reading customer:', error);
+    throw error;
+  }
+}
+
+async function getAllCustomers() {
+  try {
+    const querySnapshot = await getDocs(collection(db, CUSTOMERS_COLLECTION));
+    const customers = [];
+
+    querySnapshot.forEach((docSnap) => {
+      customers.push({
+        id: docSnap.id,
+        ...docSnap.data()
+      });
+    });
+
+    return customers;
+  } catch (error) {
+    console.error('Error reading customers:', error);
+    throw error;
+  }
+}
+
+async function updateCustomer(customerId, updates = {}) {
+  try {
+    const docRef = doc(db, CUSTOMERS_COLLECTION, customerId);
+    const docSnap = await getDoc(docRef);
+
+    if (!docSnap.exists()) {
+      throw new Error(`Customer with ID ${customerId} does not exist`);
+    }
+
+    const cleanUpdates = cleanCustomerUpdates(updates);
+
+    if (Object.keys(cleanUpdates).length === 0) {
+      return customerId;
+    }
+
+    await updateDoc(docRef, {
+      ...cleanUpdates,
+      updatedAt: serverTimestamp()
+    });
+
+    return customerId;
+  } catch (error) {
+    console.error('Error updating customer:', error);
+    throw error;
+  }
+}
+
+async function deleteCustomer(customerId) {
+  try {
+    const docRef = doc(db, CUSTOMERS_COLLECTION, customerId);
+    const docSnap = await getDoc(docRef);
+
+    if (!docSnap.exists()) {
+      throw new Error(`Customer with ID ${customerId} does not exist`);
+    }
+
+    await deleteDoc(docRef);
+    return customerId;
+  } catch (error) {
+    console.error('Error deleting customer:', error);
+    throw error;
+  }
+}
+
+async function createMonthlyPass(monthlyPass = {}) {
+  const monthlyPassRecord = buildMonthlyPassRecord(monthlyPass);
+
+  if (!monthlyPassRecord.customerId) {
+    throw new Error('customerId is required.');
+  }
+
+  if (!monthlyPassRecord.planType) {
+    throw new Error('planType is required.');
+  }
+
+  const monthlyPassRef = createGeneratedDocRef(MONTHLY_PASSES_COLLECTION);
+  await setDoc(monthlyPassRef, monthlyPassRecord);
+
+  return monthlyPassRef.id;
+}
+
+async function getMonthlyPass(passId) {
+  try {
+    const docRef = doc(db, MONTHLY_PASSES_COLLECTION, passId);
+    const docSnap = await getDoc(docRef);
+
+    if (!docSnap.exists()) {
+      return null;
+    }
+
+    return {
+      id: docSnap.id,
+      ...docSnap.data()
+    };
+  } catch (error) {
+    console.error('Error reading monthly pass:', error);
+    throw error;
+  }
+}
+
+async function getAllMonthlyPasses() {
+  try {
+    const querySnapshot = await getDocs(collection(db, MONTHLY_PASSES_COLLECTION));
+    const passes = [];
+
+    querySnapshot.forEach((docSnap) => {
+      passes.push({
+        id: docSnap.id,
+        ...docSnap.data()
+      });
+    });
+
+    return passes;
+  } catch (error) {
+    console.error('Error reading monthly passes:', error);
+    throw error;
+  }
+}
+
+async function updateMonthlyPass(passId, updates = {}) {
+  try {
+    const docRef = doc(db, MONTHLY_PASSES_COLLECTION, passId);
+    const docSnap = await getDoc(docRef);
+
+    if (!docSnap.exists()) {
+      throw new Error(`Monthly pass with ID ${passId} does not exist`);
+    }
+
+    const cleanUpdates = cleanMonthlyPassUpdates(updates);
+
+    if (Object.keys(cleanUpdates).length === 0) {
+      return passId;
+    }
+
+    await updateDoc(docRef, {
+      ...cleanUpdates,
+      updatedAt: serverTimestamp()
+    });
+
+    return passId;
+  } catch (error) {
+    console.error('Error updating monthly pass:', error);
+    throw error;
+  }
+}
+
+async function deleteMonthlyPass(passId) {
+  try {
+    const docRef = doc(db, MONTHLY_PASSES_COLLECTION, passId);
+    const docSnap = await getDoc(docRef);
+
+    if (!docSnap.exists()) {
+      throw new Error(`Monthly pass with ID ${passId} does not exist`);
+    }
+
+    await deleteDoc(docRef);
+    return passId;
+  } catch (error) {
+    console.error('Error deleting monthly pass:', error);
+    throw error;
+  }
+}
+
+async function createCustomerAndMonthlyPass({ customer = {}, monthlyPass = {} } = {}) {
+  const customerId = await createCustomer(customer);
+  const passId = await createMonthlyPass({
+    ...monthlyPass,
+    customerId
+  });
+
+  return {
+    customerId,
+    passId
+  };
+}
+
+export {
+  createCustomer,
+  getCustomer,
+  getAllCustomers,
+  updateCustomer,
+  deleteCustomer,
+  createMonthlyPass,
+  getMonthlyPass,
+  getAllMonthlyPasses,
+  updateMonthlyPass,
+  deleteMonthlyPass,
+  createCustomerAndMonthlyPass
+};

--- a/cms-app/src/api/visits-crud.js
+++ b/cms-app/src/api/visits-crud.js
@@ -1,0 +1,158 @@
+import { doc, setDoc, getDoc, updateDoc, deleteDoc, collection, getDocs, serverTimestamp } from "firebase/firestore";
+import { db } from "./firebaseconfig";
+
+const VISITS_COLLECTION = "Visits";
+const VALID_WASH_TYPES = new Set(['B', 'D', 'U']);
+const VALID_PAYMENT_TYPES = new Set(['cash', 'credit', 'free', 'book']);
+
+function cleanText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function createGeneratedDocRef() {
+  return doc(collection(db, VISITS_COLLECTION));
+}
+
+function cleanVisitUpdates(updates = {}) {
+  return {
+    ...(updates.typeOfWash !== undefined ? { typeOfWash: cleanText(updates.typeOfWash).toUpperCase() } : {}),
+    ...(updates.typeOfPayment !== undefined ? { typeOfPayment: cleanText(updates.typeOfPayment).toLowerCase() } : {}),
+    ...(updates.monthlyId !== undefined ? { monthlyId: cleanText(updates.monthlyId) } : {}),
+    ...(updates.userId !== undefined ? { userId: cleanText(updates.userId) } : {})
+  };
+}
+
+function buildVisitRecord(visit = {}) {
+  const typeOfWash = cleanText(visit.typeOfWash).toUpperCase();
+  const typeOfPayment = cleanText(visit.typeOfPayment).toLowerCase();
+
+  if (!VALID_WASH_TYPES.has(typeOfWash)) {
+    throw new Error(`Invalid typeOfWash: "${visit.typeOfWash}". Must be one of: B, D, U`);
+  }
+
+  if (!VALID_PAYMENT_TYPES.has(typeOfPayment)) {
+    throw new Error(`Invalid typeOfPayment: "${visit.typeOfPayment}". Must be one of: cash, credit, free, book`);
+  }
+
+  return {
+    typeOfWash,
+    typeOfPayment,
+    monthlyId: cleanText(visit.monthlyId),
+    userId: cleanText(visit.userId),
+    date: serverTimestamp(),
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp()
+  };
+}
+
+async function createVisit(visit = {}) {
+  const visitRecord = buildVisitRecord(visit);
+  const visitRef = createGeneratedDocRef();
+
+  await setDoc(visitRef, visitRecord);
+
+  return visitRef.id;
+}
+
+async function getVisit(visitId) {
+  try {
+    const docRef = doc(db, VISITS_COLLECTION, visitId);
+    const docSnap = await getDoc(docRef);
+
+    if (!docSnap.exists()) {
+      return null;
+    }
+
+    return {
+      id: docSnap.id,
+      ...docSnap.data()
+    };
+  } catch (error) {
+    console.error('Error reading visit:', error);
+    throw error;
+  }
+}
+
+async function getAllVisits() {
+  try {
+    const querySnapshot = await getDocs(collection(db, VISITS_COLLECTION));
+    const visits = [];
+
+    querySnapshot.forEach((docSnap) => {
+      visits.push({
+        id: docSnap.id,
+        ...docSnap.data()
+      });
+    });
+
+    return visits;
+  } catch (error) {
+    console.error('Error reading visits:', error);
+    throw error;
+  }
+}
+
+async function updateVisit(visitId, updates = {}) {
+  try {
+    const docRef = doc(db, VISITS_COLLECTION, visitId);
+    const docSnap = await getDoc(docRef);
+
+    if (!docSnap.exists()) {
+      throw new Error(`Visit with ID ${visitId} does not exist`);
+    }
+
+    const cleanUpdates = cleanVisitUpdates(updates);
+
+    if (cleanUpdates.typeOfWash && !VALID_WASH_TYPES.has(cleanUpdates.typeOfWash)) {
+      throw new Error(`Invalid typeOfWash: "${updates.typeOfWash}". Must be one of: B, D, U`);
+    }
+
+    if (cleanUpdates.typeOfPayment && !VALID_PAYMENT_TYPES.has(cleanUpdates.typeOfPayment)) {
+      throw new Error(`Invalid typeOfPayment: "${updates.typeOfPayment}". Must be one of: cash, credit, free, book`);
+    }
+
+    if (Object.keys(cleanUpdates).length === 0) {
+      return visitId;
+    }
+
+    await updateDoc(docRef, {
+      ...cleanUpdates,
+      updatedAt: serverTimestamp()
+    });
+
+    return visitId;
+  } catch (error) {
+    console.error('Error updating visit:', error);
+    throw error;
+  }
+}
+
+async function deleteVisit(visitId) {
+  try {
+    const docRef = doc(db, VISITS_COLLECTION, visitId);
+    const docSnap = await getDoc(docRef);
+
+    if (!docSnap.exists()) {
+      throw new Error(`Visit with ID ${visitId} does not exist`);
+    }
+
+    await deleteDoc(docRef);
+    return visitId;
+  } catch (error) {
+    console.error('Error deleting visit:', error);
+    throw error;
+  }
+}
+
+async function logVisit(visit = {}) {
+  return createVisit(visit);
+}
+
+export {
+  createVisit,
+  getVisit,
+  getAllVisits,
+  updateVisit,
+  deleteVisit,
+  logVisit
+};

--- a/cms-app/src/tests/monthly-subscription-crud.test.js
+++ b/cms-app/src/tests/monthly-subscription-crud.test.js
@@ -1,0 +1,237 @@
+import { beforeAll, afterAll, describe, expect, test } from 'vitest';
+import {
+  getFirestore,
+  connectFirestoreEmulator,
+  doc,
+  deleteDoc,
+} from "firebase/firestore";
+import {
+  getAuth,
+  connectAuthEmulator,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+} from "firebase/auth";
+import { deleteApp } from "firebase/app";
+import { app } from "../api/firebaseconfig.js";
+import {
+  createCustomer,
+  getCustomer,
+  createMonthlyPass,
+  getMonthlyPass,
+  createCustomerAndMonthlyPass,
+  updateCustomer,
+  updateMonthlyPass,
+} from "../api/monthly-subscription-crud.js";
+
+const db = getFirestore(app);
+connectFirestoreEmulator(db, "127.0.0.1", 8080);
+
+const auth = getAuth(app);
+connectAuthEmulator(auth, "http://127.0.0.1:9099", { disableWarnings: true });
+
+beforeAll(async () => {
+  try {
+    await signInWithEmailAndPassword(auth, "test@example.com", "password123");
+  } catch {
+    try {
+      await createUserWithEmailAndPassword(auth, "test@example.com", "password123");
+    } catch (createError) {
+      if (createError.code === 'auth/email-already-in-use') {
+        await signInWithEmailAndPassword(auth, "test@example.com", "password123");
+      } else {
+        console.error("Failed to authenticate test user:", createError);
+        throw createError;
+      }
+    }
+  }
+});
+
+afterAll(async () => {
+  await signOut(auth);
+  await deleteApp(app);
+});
+
+async function cleanupCustomer(customerId) {
+  try {
+    await deleteDoc(doc(db, "Customers", customerId));
+  } catch (error) {
+    console.error(error.message);
+  }
+}
+
+async function cleanupMonthlyPass(passId) {
+  try {
+    await deleteDoc(doc(db, "MonthlyPasses", passId));
+  } catch (error) {
+    console.error(error.message);
+  }
+}
+
+describe("Monthly subscription backend", () => {
+  test("creates a customer without accepting frontend ids or dates", async () => {
+    const customerId = await createCustomer({
+      customerId: 'frontend-id',
+      createdAt: '2000-01-01',
+      name: 'Jane Doe',
+      contactPerson: 'Jane Doe',
+      address: {
+        streetAddress: '123 Main St',
+        city: 'Spokane',
+        state: 'WA',
+        zipCode: '99201'
+      },
+      phone: '5095551234',
+      email: 'jane@example.com'
+    });
+
+    expect(customerId).not.toBe('frontend-id');
+
+    const customer = await getCustomer(customerId);
+    expect(customer).toBeDefined();
+    expect(customer.id).toBe(customerId);
+    expect(customer.name).toBe('Jane Doe');
+    expect(customer.contactPerson).toBe('Jane Doe');
+    expect(customer.address).toEqual({
+      streetAddress: '123 Main St',
+      city: 'Spokane',
+      state: 'WA',
+      zipCode: '99201'
+    });
+    expect(customer.phone).toBe('5095551234');
+    expect(customer.email).toBe('jane@example.com');
+    expect(customer.customerId).toBeUndefined();
+    expect(customer.createdAt).toBeDefined();
+
+    await cleanupCustomer(customerId);
+  });
+
+  test("creates a monthly pass with default status and update flag", async () => {
+    const customerId = await createCustomer({
+      name: 'Pass Owner',
+      address: {},
+      phone: '5095550000',
+      email: 'owner@example.com'
+    });
+
+    const passId = await createMonthlyPass({
+      passId: 'frontend-pass-id',
+      createdAt: '2000-01-01',
+      customerId,
+      planType: 'deluxe',
+      planNumberId: 'PN-100',
+      vehicleInfo: {
+        year: '2022',
+        make: 'Toyota',
+        model: 'Camry',
+        color: 'Blue'
+      },
+      notes: 'Initial signup',
+      status: 'paid',
+      updateInfoFlag: false
+    });
+
+    expect(passId).not.toBe('frontend-pass-id');
+
+    const pass = await getMonthlyPass(passId);
+    expect(pass).toBeDefined();
+    expect(pass.id).toBe(passId);
+    expect(pass.customerId).toBe(customerId);
+    expect(pass.planType).toBe('deluxe');
+    expect(pass.planNumberId).toBe('PN-100');
+    expect(pass.vehicleInfo).toEqual({
+      year: '2022',
+      make: 'Toyota',
+      model: 'Camry',
+      color: 'Blue'
+    });
+    expect(pass.notes).toBe('Initial signup');
+    expect(pass.status).toBe('needs credit card information');
+    expect(pass.updateInfoFlag).toBe(true);
+    expect(pass.passId).toBeUndefined();
+    expect(pass.createdAt).toBeDefined();
+
+    await cleanupMonthlyPass(passId);
+    await cleanupCustomer(customerId);
+  });
+
+  test("creates linked customer and monthly pass in one call", async () => {
+    const result = await createCustomerAndMonthlyPass({
+      customer: {
+        name: 'Linked Customer',
+        address: {},
+        phone: '5095552222',
+        email: 'linked@example.com'
+      },
+      monthlyPass: {
+        planType: 'ultimate',
+        planNumberId: 'PN-200',
+        vehicleInfo: {
+          year: '2023',
+          make: 'Honda',
+          model: 'Civic',
+          color: 'White'
+        }
+      }
+    });
+
+    expect(result.customerId).toBeDefined();
+    expect(result.passId).toBeDefined();
+
+    const customer = await getCustomer(result.customerId);
+    const pass = await getMonthlyPass(result.passId);
+
+    expect(customer.id).toBe(result.customerId);
+    expect(pass.id).toBe(result.passId);
+    expect(pass.customerId).toBe(result.customerId);
+
+    await cleanupMonthlyPass(result.passId);
+    await cleanupCustomer(result.customerId);
+  });
+
+  test("updates customer and monthly pass without allowing id or date fields", async () => {
+    const customerId = await createCustomer({
+      name: 'Update Me',
+      address: {},
+      phone: '5095553333',
+      email: 'update@example.com'
+    });
+
+    const passId = await createMonthlyPass({
+      customerId,
+      planType: 'basic',
+      planNumberId: 'PN-300',
+      vehicleInfo: {
+        year: '2021',
+        make: 'Ford',
+        model: 'Escape',
+        color: 'Gray'
+      }
+    });
+
+    await updateCustomer(customerId, {
+      customerId: 'blocked',
+      createdAt: '2001-01-01',
+      name: 'Updated Customer'
+    });
+
+    await updateMonthlyPass(passId, {
+      passId: 'blocked',
+      closedAt: '2001-01-01',
+      status: 'active',
+      updateInfoFlag: false
+    });
+
+    const updatedCustomer = await getCustomer(customerId);
+    const updatedPass = await getMonthlyPass(passId);
+
+    expect(updatedCustomer.name).toBe('Updated Customer');
+    expect(updatedCustomer.customerId).toBeUndefined();
+    expect(updatedPass.status).toBe('active');
+    expect(updatedPass.updateInfoFlag).toBe(false);
+    expect(updatedPass.passId).toBeUndefined();
+
+    await cleanupMonthlyPass(passId);
+    await cleanupCustomer(customerId);
+  });
+});

--- a/cms-app/src/tests/visits-crud.test.js
+++ b/cms-app/src/tests/visits-crud.test.js
@@ -1,0 +1,139 @@
+import { beforeAll, afterAll, describe, expect, test } from 'vitest';
+import {
+  getFirestore,
+  connectFirestoreEmulator,
+  doc,
+  deleteDoc,
+} from "firebase/firestore";
+import {
+  getAuth,
+  connectAuthEmulator,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+} from "firebase/auth";
+import { deleteApp } from "firebase/app";
+import { app } from "../api/firebaseconfig.js";
+import {
+  createVisit,
+  getVisit,
+  getAllVisits,
+  updateVisit,
+  deleteVisit,
+  logVisit,
+} from "../api/visits-crud.js";
+
+const db = getFirestore(app);
+connectFirestoreEmulator(db, "127.0.0.1", 8080);
+
+const auth = getAuth(app);
+connectAuthEmulator(auth, "http://127.0.0.1:9099", { disableWarnings: true });
+
+beforeAll(async () => {
+  try {
+    await signInWithEmailAndPassword(auth, "test@example.com", "password123");
+  } catch {
+    try {
+      await createUserWithEmailAndPassword(auth, "test@example.com", "password123");
+    } catch (createError) {
+      if (createError.code === 'auth/email-already-in-use') {
+        await signInWithEmailAndPassword(auth, "test@example.com", "password123");
+      } else {
+        console.error("Failed to authenticate test user:", createError);
+        throw createError;
+      }
+    }
+  }
+});
+
+afterAll(async () => {
+  await signOut(auth);
+  await deleteApp(app);
+});
+
+async function cleanupVisit(visitId) {
+  try {
+    await deleteDoc(doc(db, "Visits", visitId));
+  } catch (error) {
+    console.error(error.message);
+  }
+}
+
+describe("Visits CRUD Operations (emulator)", () => {
+  test("creates a visit with backend-generated id and timestamp", async () => {
+    const visitId = await createVisit({
+      visitId: 'frontend-id',
+      date: '2000-01-01',
+      typeOfWash: 'B',
+      typeOfPayment: 'cash',
+      monthlyId: 'M123',
+      userId: 'U123'
+    });
+
+    expect(visitId).not.toBe('frontend-id');
+
+    const visit = await getVisit(visitId);
+    expect(visit).toBeDefined();
+    expect(visit.id).toBe(visitId);
+    expect(visit.typeOfWash).toBe('B');
+    expect(visit.typeOfPayment).toBe('cash');
+    expect(visit.monthlyId).toBe('M123');
+    expect(visit.userId).toBe('U123');
+    expect(visit.visitId).toBeUndefined();
+    expect(visit.date).toBeDefined();
+    expect(visit.createdAt).toBeDefined();
+
+    await cleanupVisit(visitId);
+  });
+
+  test("logs visits through the helper alias", async () => {
+    const visitId = await logVisit({
+      typeOfWash: 'D',
+      typeOfPayment: 'free'
+    });
+
+    const visit = await getVisit(visitId);
+    expect(visit.typeOfWash).toBe('D');
+    expect(visit.typeOfPayment).toBe('free');
+
+    await cleanupVisit(visitId);
+  });
+
+  test("returns all visits and updates fields without allowing frontend ids or dates", async () => {
+    const visitId = await createVisit({
+      typeOfWash: 'U',
+      typeOfPayment: 'book',
+      monthlyId: 'M777'
+    });
+
+    await updateVisit(visitId, {
+      visitId: 'blocked',
+      date: '2001-01-01',
+      typeOfPayment: 'credit',
+      userId: 'USER-1'
+    });
+
+    const visits = await getAllVisits();
+    const matchedVisit = visits.find((item) => item.id === visitId);
+
+    expect(matchedVisit).toBeDefined();
+    expect(matchedVisit.typeOfPayment).toBe('credit');
+    expect(matchedVisit.userId).toBe('USER-1');
+    expect(matchedVisit.visitId).toBeUndefined();
+
+    await cleanupVisit(visitId);
+  });
+
+  test("deletes an existing visit document", async () => {
+    const visitId = await createVisit({
+      typeOfWash: 'B',
+      typeOfPayment: 'cash'
+    });
+
+    const deletedId = await deleteVisit(visitId);
+    expect(deletedId).toBe(visitId);
+
+    const visit = await getVisit(visitId);
+    expect(visit).toBeNull();
+  });
+});


### PR DESCRIPTION
## Adds server-side CRUD for Customers, MonthlyPasses, and Visits. Ensures the server generates document IDs and timestamps, enforces validation and default values, and includes tests using the emulator.

Files added:
- src/api/monthly-subscription-crud.js
- src/api/visits-crud.js
- src/tests/monthly-subscription-crud.test.js
- src/tests/visits-crud.test.js



